### PR TITLE
Removed mocker as test dependency, replaced with mock

### DIFF
--- a/magicicada/server/server.py
+++ b/magicicada/server/server.py
@@ -1688,8 +1688,8 @@ class PutContentResponse(SimpleRequestResponse):
             self._log_exception(exc)
             yield self._send_protocol_error(failure)
             yield self.done()
-        except Exception:
-            yield self.internal_error(Failure())
+        except Exception as e:
+            yield self.internal_error(Failure(e))
 
     def _processMessage(self, message):
         """Receive the content for the upload."""

--- a/magicicada/u1sync/tests/test_client.py
+++ b/magicicada/u1sync/tests/test_client.py
@@ -15,7 +15,7 @@
 
 """Test the client code."""
 
-from mocker import Mocker
+import mock
 from twisted.trial.unittest import TestCase
 
 from magicicada.u1sync import client
@@ -31,18 +31,15 @@ class SyncStorageClientTest(TestCase):
         self.patch(client.StorageClient, 'connectionMade',
                    lambda s: called.append(True))
         c = client.SyncStorageClient()
-        mocker = Mocker()
-        obj = mocker.mock()
-        obj.current_protocol
-        mocker.result(None)
-        obj.current_protocol = c
-        obj.observer.connected()
+        obj = mock.Mock()
+        obj.current_protocol.return_value = c
         c.factory = obj
 
         # call and test
-        with mocker:
-            c.connectionMade()
+        c.connectionMade()
+
         self.assertTrue(called)
+        obj.observer.connected.assert_called_once_with()
 
     def test_conn_lost_call_parent(self):
         """The connectionLost method should call the parent."""
@@ -51,13 +48,12 @@ class SyncStorageClientTest(TestCase):
         self.patch(client.StorageClient, 'connectionLost',
                    lambda s, r: called.append(True))
         c = client.SyncStorageClient()
-        mocker = Mocker()
-        obj = mocker.mock()
-        obj.current_protocol
-        mocker.result(None)
+        obj = mock.Mock()
+        obj.current_protocol.return_value = None
         c.factory = obj
 
         # call and test
-        with mocker:
-            c.connectionLost()
+        c.connectionLost()
+
         self.assertTrue(called)
+        obj.observer.connected.assert_not_called()

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -5,6 +5,5 @@ pycairo==1.18.1
 pygobject==3.36.1
 meliae==0.5.1
 mock==3.0.5
-mocker==1.1.1
 pyinotify==0.9.6
 rst2html5==1.10.6

--- a/test
+++ b/test
@@ -23,13 +23,13 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.abspath('magicicada'))
 sys.path.insert(0, os.path.abspath('lib'))
 
 TESTDIRS = [
+    'lib',
     'magicicada',
 ]
-for td in TESTDIRS:
-    sys.path.insert(0, os.path.abspath(td))
 
 # import unittest first, to break an import loop in the twisted.trial 
 # package: reporter -> unittest -> _asyncrunner -> reporter


### PR DESCRIPTION
Cleanup and fix ssl tests, removing mocker in the process
Cleanup and modernization of notify delivery tests (removed mocker)
Cleanup and mocker removal from test_server