### PR TITLE
More misc fixes in preparation for Python 3 port

### DIFF
--- a/dev-scripts/cmd_client.py
+++ b/dev-scripts/cmd_client.py
@@ -546,10 +546,10 @@ class ClientCmd(cmd.Cmd):
         def go():
             """Actually do it."""
             tini = time.time()
-            for _ in xrange(intensity):
+            for _ in range(intensity):
                 name = u"testdir-" + unicode(uuid.uuid4())
                 req = yield make_dir(self.volume, subroot_id, name)
-                for _ in xrange(intensity):
+                for _ in range(intensity):
                     name = u"testfile-" + unicode(uuid.uuid4())
                     yield make_file(self.volume, req.new_id, name)
             tend = time.time()

--- a/lib/ubuntuone/supervisor/heartbeat_listener.py
+++ b/lib/ubuntuone/supervisor/heartbeat_listener.py
@@ -30,7 +30,7 @@ import logging
 import os
 import sys
 import time
-import xmlrpclib
+from xmlrpclib import Fault
 
 from supervisor import childutils, states
 from supervisor.events import EventTypes, getEventNameByType
@@ -172,7 +172,7 @@ class HeartbeatListener(object):
         try:
             self.rpc.supervisor.stopProcess(name)
             self.logger.debug("Process %s stopped.", name)
-        except xmlrpclib.Fault as what:
+        except Fault as what:
             self.logger.error(
                 'Failed to stop process %s (last heartbeat: %s), exiting: %s',
                 name, when_client_heartbeat, what)
@@ -180,7 +180,7 @@ class HeartbeatListener(object):
         try:
             self.rpc.supervisor.startProcess(name)
             self.logger.debug("Process %s started.", name)
-        except xmlrpclib.Fault as what:
+        except Fault as what:
             self.logger.error('Failed to start process %s after stopping it, '
                               'exiting: %s', name, what)
             raise

--- a/lib/ubuntuone/supervisor/tests/test_heartbeat_listener.py
+++ b/lib/ubuntuone/supervisor/tests/test_heartbeat_listener.py
@@ -21,8 +21,8 @@
 import json
 import logging
 import time
-import xmlrpclib
 from StringIO import StringIO
+from xmlrpclib import Fault
 
 import mock
 from supervisor import states, childutils
@@ -62,11 +62,11 @@ class HeartbeatListenerTestCase(BaseTestCase):
 
     def test_restart_fail_stop(self):
         """Test the restart method failing to stop the process."""
-        self.rpc.supervisor.stopProcess.side_effect = xmlrpclib.Fault(
+        self.rpc.supervisor.stopProcess.side_effect = Fault(
             42, "Failed to stop the process.")
 
         last = time.time()
-        with self.assertRaises(xmlrpclib.Fault):
+        with self.assertRaises(Fault):
             self.listener.restart("foo", last)
 
         msg = "Failed to stop process %s (last heartbeat: %s), exiting: %s"
@@ -76,11 +76,11 @@ class HeartbeatListenerTestCase(BaseTestCase):
 
     def test_restart_fail_start(self):
         """Test the restart method failing to start the process."""
-        self.rpc.supervisor.startProcess.side_effect = xmlrpclib.Fault(
+        self.rpc.supervisor.startProcess.side_effect = Fault(
             42, "Failed to start the process.")
 
         last = time.time()
-        with self.assertRaises(xmlrpclib.Fault):
+        with self.assertRaises(Fault):
             self.listener.restart("foo", last)
 
         msg = 'Failed to start process %s after stopping it, exiting: %s'

--- a/lib/utilities/testlib.py
+++ b/lib/utilities/testlib.py
@@ -18,7 +18,7 @@
 
 """Library of functions used in tests."""
 
-from __future__ import unicode_literals
+from __future__ import print_function, unicode_literals
 
 import os
 import re
@@ -26,9 +26,10 @@ import re
 from unittest import TestSuite, TestLoader, defaultTestLoader
 
 import django
-
 from django.test.runner import DiscoverRunner
+from twisted.internet import defer
 from twisted.internet.base import DelayedCall
+from twisted.python import failure
 from twisted.trial.reporter import (
     TreeReporter, TestResultDecorator, SubunitReporter)
 from twisted.trial.runner import TrialRunner
@@ -37,7 +38,11 @@ from twisted.trial.runner import TrialRunner
 COVERAGE_DIR = "./tmp/coverage"
 WORKING_DIR = "./tmp/trial"
 
-django.setup()
+
+def set_twisted_debug():
+    DelayedCall.debug = True
+    failure.startDebugMode()
+    defer.setDebugging(True)
 
 
 class StopOnFailureDecorator(TestResultDecorator):
@@ -92,7 +97,7 @@ class LogsOnFailureDecorator(TestResultDecorator):
             if os.path.exists(log):
                 with open(log) as fh:
                     fh.seek(prev_pos)
-                    print(fh.read())
+                    print(fh.read(), end=' ')
                 print("------------ end log:", repr(log))
             else:
                 print("------------ log not found!")
@@ -148,12 +153,14 @@ def load_unittest(relpath, loader=None):
 
 class MagicicadaRunner(DiscoverRunner):
 
-    def __init__(self, factory, filter_test, verbosity=1):
+    def __init__(self, factory, filter_test, verbosity=1, debug=False):
         self.factory = factory
         self.loader = RegexTestLoader(filter_test)
         self.server_suite = TestSuite()
         self.non_server_suite = TestSuite()
         super(MagicicadaRunner, self).__init__(verbosity=verbosity)
+        if debug:
+            set_twisted_debug()
 
     def add_tests_for_dir(self, testdir, testpaths, topdir):
         """Helper for build_suite; searches a particular testdir for tests.
@@ -239,9 +246,6 @@ def test_with_trial(options, topdir, testdirs, testpaths):
     if options.ignore:
         exclude_re = re.compile('.*%s.*' % options.ignore)
 
-    if options.debug:
-        DelayedCall.debug = True
-
     def filter_test(t):
         result = True
         try:
@@ -255,7 +259,10 @@ def test_with_trial(options, topdir, testdirs, testpaths):
                 result = False
         return result
 
+    django.setup()
+
     runner = MagicicadaRunner(
-        factory, filter_test, verbosity=options.verbosity)
+        factory, filter_test, verbosity=options.verbosity,
+        debug=options.debug)
     result = runner.run_tests(test_labels=(topdir, testdirs, testpaths))
     return not result.wasSuccessful()

--- a/magicicada/filesync/tests/test_dao.py
+++ b/magicicada/filesync/tests/test_dao.py
@@ -1460,7 +1460,7 @@ class TestSQLStatementCount(StorageDALTestCase):
         user = self.create_user()
         directory = user.root.make_subdirectory('test')
         hash_ = self.factory.get_fake_hash()
-        name = self.factory.get_unique_unicode()
+        name = self.factory.get_unique_string()
         size = self.factory.get_unique_integer()
         crc32 = self.factory.get_unique_integer()
         storage_key = uuid.uuid4()

--- a/magicicada/testing/factory.py
+++ b/magicicada/testing/factory.py
@@ -60,8 +60,6 @@ class Factory(object):
         return prefix + ''.join(
             random.choice(BASE_CHARS) for i in range(extra_length))
 
-    get_unique_unicode = get_unique_string
-
     def get_fake_hash(self, key=None):
         """Return a hashkey."""
         if key is None:

--- a/magicicada/txlog/tests/test_utils.py
+++ b/magicicada/txlog/tests/test_utils.py
@@ -57,11 +57,11 @@ class TransactionLogUtilsTestCase(BaseTransactionLogTestCase):
         txlog3 = self.factory.make_transaction_log()
 
         self._create_db_worker_last_row_entry(
-            self.factory.get_unique_unicode(), txlog3)
+            self.factory.get_unique_string(), txlog3)
         self._create_db_worker_last_row_entry(
-            self.factory.get_unique_unicode(), txlog1)
+            self.factory.get_unique_string(), txlog1)
         self._create_db_worker_last_row_entry(
-            self.factory.get_unique_unicode(), txlog2)
+            self.factory.get_unique_string(), txlog2)
 
         self.assertEqual(
             (txlog1.id, txlog1.timestamp), utils.get_last_row('some worker'))
@@ -73,12 +73,12 @@ class TransactionLogUtilsTestCase(BaseTransactionLogTestCase):
         txlog2 = self.factory.make_transaction_log()
         txlog3 = self.factory.make_transaction_log()
 
-        worker_name = self.factory.get_unique_unicode()
+        worker_name = self.factory.get_unique_string()
         self._create_db_worker_last_row_entry(worker_name, txlog3)
         self._create_db_worker_last_row_entry(
-            self.factory.get_unique_unicode(), txlog1)
+            self.factory.get_unique_string(), txlog1)
         self._create_db_worker_last_row_entry(
-            self.factory.get_unique_unicode(), txlog2)
+            self.factory.get_unique_string(), txlog2)
 
         self.assertEqual(
             (txlog3.id, txlog3.timestamp), utils.get_last_row(worker_name))
@@ -86,7 +86,7 @@ class TransactionLogUtilsTestCase(BaseTransactionLogTestCase):
     def test_update_last_row_with_no_data(self):
         """Test the update_last_row function when no data is present."""
         txlog = self.factory.make_transaction_log()
-        worker_name = self.factory.get_unique_unicode()
+        worker_name = self.factory.get_unique_string()
         utils.update_last_row(worker_name=worker_name, txlog=txlog)
 
         result = DBWorkerLastRow.objects.get(worker_id=worker_name)
@@ -99,7 +99,7 @@ class TransactionLogUtilsTestCase(BaseTransactionLogTestCase):
         """
         txlog = self.factory.make_transaction_log()
         txlog2 = self.factory.make_transaction_log()
-        worker_name = self.factory.get_unique_unicode()
+        worker_name = self.factory.get_unique_string()
         self._create_db_worker_last_row_entry(worker_name, txlog)
         utils.update_last_row(worker_name=worker_name, txlog=txlog2)
 
@@ -221,7 +221,7 @@ class TransactionLogUtilsTestCase(BaseTransactionLogTestCase):
         owner = self.make_user_without_txlog()
         txlogs = [self.factory.make_transaction_log(owner=owner),
                   self.factory.make_transaction_log(owner=owner)]
-        worker_id = self.factory.get_unique_unicode()
+        worker_id = self.factory.get_unique_string()
         txlist = utils.get_txn_recs(num_recs=3, worker_id=worker_id)
 
         self.assertEqual([t.as_dict() for t in txlogs], txlist)
@@ -241,7 +241,7 @@ class TransactionLogUtilsTestCase(BaseTransactionLogTestCase):
         t3 = self.factory.make_transaction_log(owner=owner)
         t2.delete()
 
-        worker_id = self.factory.get_unique_unicode()
+        worker_id = self.factory.get_unique_string()
         txlist = utils.get_txn_recs(num_recs=3, worker_id=worker_id)
         self.assertEqual([t1.as_dict(), t3.as_dict()], txlist)
         txlist = utils.get_txn_recs(


### PR DESCRIPTION
Removed deprecated get_unique_unicode
Use Fault from xmlrpclib directly in the module namespace
Use range instead of xrange
Allow fo easier debugging when running tests